### PR TITLE
fixing image link for screen shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ project page: http://www.littlebigtomatoes.com/bootstrapmvc/
 
 screenshot
 
-![BootstrapMVC](http://www.littlebigtomatoes.com/wp-content/uploads/2011/09/BootstrapMVC-300x217.png)
+![BootstrapMVC](http://www.littlebigtomatoes.com/images/BootstrapMVC-300x217.png)


### PR DESCRIPTION
This updates the screen shot image url to match that of the one found at the page http://www.littlebigtomatoes.com/bootstrapmvc/
